### PR TITLE
Fix cadastro de areas de conhecimento

### DIFF
--- a/src/controller/user/userController.js
+++ b/src/controller/user/userController.js
@@ -16,13 +16,12 @@ async function verifyArea(listAreas) {
 
   await areasCollection.get().then((snapshot) => {
     return snapshot.forEach((res) => {
-      resultArea.push(res.data());
+      resultArea.push(res.data().name.toLowerCase());
     });
   });
 
-  for (let i = 0; i < listAreas.length; i += 1) {
-    if (!resultArea.includes(listAreas[i]))
-      areasCollection.add({ name: listAreas[i] });
+  if (!resultArea.includes(listAreas.toLowerCase())) {
+    await areasCollection.add({ name: listAreas });
   }
 }
 


### PR DESCRIPTION
Enquanto não estamos usando select na area de conhecimento para cadastrar o usuario, foi feito esse fix, para não cadastrar cada letra da area de conhecimento no banco