### PR TITLE
[FIX]cadastro

### DIFF
--- a/src/controller/user/userController.js
+++ b/src/controller/user/userController.js
@@ -20,8 +20,10 @@ async function verifyArea(listAreas) {
     });
   });
 
-  if (!resultArea.includes(listAreas.toLowerCase())) {
-    await areasCollection.add({ name: listAreas });
+  for (let i = 0; i < listAreas.length; i += 1) {
+    if (!resultArea.includes(listAreas[i].toLowerCase())) {
+      await areasCollection.add({ name: listAreas[i] });
+    }
   }
 }
 
@@ -68,7 +70,7 @@ async function addMenthorData(newData, response) {
       .status(200)
       .send({ success: true, msg: 'Usuário atualizado com sucesso' });
   } catch (e) {
-    return response.status.status(500).json({
+    return response.status(500).json({
       error: `Erro ao atualizar usuário : ${e}`,
     });
   }
@@ -151,7 +153,7 @@ async function addMenteeData(newData, response) {
       .status(200)
       .send({ success: true, msg: 'Usuário atualizado com sucesso' });
   } catch (e) {
-    return response.status.status(500).json({
+    return response.status(500).json({
       error: `Erro ao atualizar usuário : ${e}`,
     });
   }
@@ -241,7 +243,7 @@ module.exports = {
   async insert(request, response) {
     try {
       // eslint-disable-next-line radix
-      const flag = parseInt(request.body.flag);
+      const flag = parseInt(request.body.userType);
 
       if (flag === userType.MENTHOR) {
         await newMenthor(request, response);
@@ -360,7 +362,7 @@ module.exports = {
         .status(200)
         .send({ success: true, msg: 'Usuário atualizado com sucesso' });
     } catch (e) {
-      return response.status.status(500).json({
+      return response.status(500).json({
         error: `Erro ao atualizar usuário : ${e}`,
       });
     }

--- a/src/controller/user/userController.js
+++ b/src/controller/user/userController.js
@@ -10,23 +10,6 @@ const userType = {
   BOTH: 3,
 };
 
-async function verifyArea(listAreas) {
-  const areasCollection = db.collection('area_conhecimento');
-  const resultArea = [];
-
-  await areasCollection.get().then((snapshot) => {
-    return snapshot.forEach((res) => {
-      resultArea.push(res.data().name.toLowerCase());
-    });
-  });
-
-  for (let i = 0; i < listAreas.length; i += 1) {
-    if (!resultArea.includes(listAreas[i].toLowerCase())) {
-      await areasCollection.add({ name: listAreas[i] });
-    }
-  }
-}
-
 async function getUser(email) {
   const userCollection = db.collection('user');
   let user = null;
@@ -53,8 +36,6 @@ async function getUser(email) {
 async function addMenthorData(newData, response) {
   try {
     const { linkedin, areas, userId, userCollection } = newData;
-
-    await verifyArea(areas);
 
     if (linkedin) {
       await userCollection.doc(userId).update({ linkedin });
@@ -109,8 +90,6 @@ async function newMenthor(request, response) {
       // User exists but it's type is different
       return addMenthorData(newData, response);
     }
-
-    verifyArea(areas);
 
     const currentUserType = userType.MENTHOR;
 
@@ -283,12 +262,10 @@ module.exports = {
       const passwordHash = await bcrypt.hash(password, 8);
 
       const user = await getUser(email);
-      const resultArea = [];
+
       if (!user) {
         return response.status(400).send({ error: 'Usuário não existe.' });
       }
-
-      await verifyArea(areas);
 
       const newImage = image && image !== user.image ? image : user.image;
 
@@ -301,7 +278,7 @@ module.exports = {
         email,
         userType: flag,
         image: newImage,
-        areas: resultArea,
+        areas,
       });
 
       return response


### PR DESCRIPTION
Houveram algumas mudanças no nosso frontend que acabaram quebrando a nossa funcionalidade de cadastro de mentores/mentorados. Essa branch faz correções para que funcione novamente.
- mudança do nome de uma das variáveis que recebíamos no corpo da requisição (de `flag` para `userType`
- correção na função que inseria as áreas do novo mentor no banco de dados de áreas, antes recebíamos um _string_ do frontend, agora recebemos um _array_ (nem lembrava dessa função, me pergunto se isso não quebra algum requisito, já que abre espaço pra qualquer mentor criar uma nova área de conhecimento)