### PR TITLE
send email for password recover completed

### DIFF
--- a/src/controller/user/userController.js
+++ b/src/controller/user/userController.js
@@ -416,35 +416,25 @@ module.exports = {
     return results[0];
   },
 
+  // eslint-disable-next-line consistent-return
   async sendVerificationEmail(request, response) {
     try {
       const { email } = request.body;
 
-      let userID = null;
-
       const url = process.env.ROOT_URL || 'localhost:8080';
 
-      const userCollection = db.collection('user');
+      const user = await getUser(email);
 
-      await userCollection
-        .where('email', '==', email)
-        .limit(1)
-        .get()
-        .then((snapshot) => {
-          if (snapshot.empty) {
-            response
-              .status(404)
-              .send(`não foi encontrado um usuário com o email ${email}`);
-          }
-          snapshot.forEach((doc) => {
-            userID = doc.id;
-          });
-        });
+      if (!user) {
+        return response
+          .status(404)
+          .send(`não foi encontrado um usuário com o email ${email}`);
+      }
       const emailSettings = {
         from: process.env.EMAIL_USER,
         to: email,
         subject: `Recuperação de senha`,
-        text: `Você solicitou uma nova senha. Clique no link abaixo para defini-la:\nhttp://${url}/nova-senha/${userID}`,
+        text: `Você solicitou uma nova senha. Clique no link abaixo para defini-la:\nhttp://${url}/nova-senha/${user.id}`,
       };
 
       transporter.sendMail(emailSettings, (error) => {
@@ -456,7 +446,25 @@ module.exports = {
           .send(`email enviado com sucesso para ${email}`);
       });
     } catch (e) {
-      response.status(500).send(`erro ao enviar nova senha ${e}`);
+      response.status(500).send(`erro ao processar requisição: ${e}`);
+    }
+  },
+
+  async updatePassword(request, response) {
+    try {
+      const { id, newPassword } = request.body;
+
+      const passwordHash = await bcrypt.hash(newPassword, 8);
+
+      const userCollection = db.collection('user');
+
+      await userCollection.doc(id).update({ password: passwordHash });
+
+      return response
+        .status(200)
+        .send({ success: true, msg: 'Senha atualizada com sucesso' });
+    } catch (e) {
+      return response.status(500).send({ error: e });
     }
   },
 };

--- a/src/controller/user/userController.js
+++ b/src/controller/user/userController.js
@@ -484,7 +484,7 @@ module.exports = {
             }
           }
           response.status(401).send({
-            message: 'solicitação de troca de senha inválida',
+            message: 'Solicitação de troca de senha inválida',
           });
           return false;
         })
@@ -503,7 +503,7 @@ module.exports = {
       });
 
       return response
-        .status(200)
+        .status(202)
         .send({ success: true, msg: 'Senha atualizada com sucesso' });
     } catch (e) {
       return response

--- a/src/routes.js
+++ b/src/routes.js
@@ -49,6 +49,7 @@ routes.post(
  */
 routes.get('/users', authMiddleware, userController.get);
 routes.post('/users', upload.single('image'), userController.insert);
+routes.post('/passwordRecuperationLink', userController.sendVerificationEmail);
 routes.put(
   '/users',
   upload.single('image'),

--- a/src/routes.js
+++ b/src/routes.js
@@ -50,6 +50,7 @@ routes.post(
 routes.get('/users', authMiddleware, userController.get);
 routes.post('/users', upload.single('image'), userController.insert);
 routes.post('/passwordRecuperationLink', userController.sendVerificationEmail);
+routes.put('/setPassword/', userController.updatePassword);
 routes.put(
   '/users',
   upload.single('image'),

--- a/src/routes.js
+++ b/src/routes.js
@@ -50,7 +50,7 @@ routes.post(
 routes.get('/users', authMiddleware, userController.get);
 routes.post('/users', upload.single('image'), userController.insert);
 routes.post('/passwordRecuperationLink', userController.sendVerificationEmail);
-routes.put('/setPassword/', userController.updatePassword);
+routes.post('/setPassword/', userController.updatePassword);
 routes.put(
   '/users',
   upload.single('image'),


### PR DESCRIPTION
## Backend esqueci minha senha
O usuário preenche seu email e ele é enviado para a API.
A API um email para o usuário com o link para ele definir uma nova senha.

Não sei se fiz nas melhores práticas (algumas tenho certeza que não)... Estou aberto a sugestões de modificação para adequar isso.

### Para testar
#### Parte 1: envio do email com link de recuperação.
**POST** `localhost:3000/passwordRecuperationLink`
**Body**:
```
{
  "email": "um-email-real@email.com"
}
```
**Responses**:
200: Ok - Mensagem: email enviado com sucesso para {email}.
404: Not Found - Mensagem: não foi encontrado um usuário com o email {email}.
400: Bad Request - Erro ao enviar email: {error}.
500: Internal Server Error - Erro ao processar requisição: {error}.

Quando o email é enviado com sucesso, a mensagem que chega vem mais ou menos neste modelo:
```
from: redementorpucrs@gmail.com
subject: Recuperação de senha
to: Alexandre Bing

Você solicitou uma nova senha. Clique no link abaixo para defini-la:
http://localhost:8080/nova-senha/FdPCObwZ24IKkLCC2uS1
```

A solicitação expira se não for feita em até 24h. Após isso, o procedimento deve ser feito novamente.

#### Parte 2: definição da nova senha

**POST** `localhost:3000/setPassword`
**Body**:
```
{
    "id": "id-que-vem-na-URL-do-email",
    "newPassword": "nova senha"
}
```
**Responses**:
202: Accepted - Mensagem: Senha atualizada com sucesso.
404: Not Found - Mensagem:usuário não encontrado: {error}.
401: Unauthorized - Mensagem: Solicitação de troca de senha inválida.
500: Internal Server Error - Erro ao processar requisição: {error}.

Quando esse post é feito é criado um novo `date`, que é comparado com aquele criado e inserido no BD quando a requisição para a nova senha foi feita. Se este date é de um dia anterior ao que tem no BD, a troca de senha é feita e a data no BD vira nula, invalidando novas trocas de senha sem que antes o link seja enviado por email (mesmo que o link seja sempre o mesmo).

**Nota**: para definir a URL, criei uma variável
`const url = process.env.ROOT_URL || 'localhost:8080';`
que é pra pegar a url base do ambiente da AWS quando estiver lá.
**Nota 2**: esse hash é o ID do usuário, como combinamos ontem eu aula. Logo, essa url vai sempre possibilitar a troca de senha (não expira).